### PR TITLE
Make readSDMX explicitly check for a 200 HTTP status.

### DIFF
--- a/tests/testthat/test_Main.R
+++ b/tests/testthat/test_Main.R
@@ -76,3 +76,23 @@ test_that("readSDMX - SDMXDataStructureDefinition (DSD) - 2.0",{
   expect_is(dsd@codelists, "SDMXCodelists")
   expect_is(dsd@datastructures, "SDMXDataStructures")
 })
+
+test_that("readSDMX - Catch 400 bad request", {
+  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  expect_error(
+    sdmx <- readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "bad_ref")
+  )
+})
+
+test_that("readSDMX - Catch good request that fails for other reason (bad proxy)", {
+  testthat::skip_on_travis()
+  testthat::skip_on_cran()
+  old_opts <- options()
+  options(RCurlOptions = list("proxy" = "bad_proxy"))
+  
+  expect_error(
+    sdmx <- readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "SADG2015")
+  )
+  options(old_opts)
+})


### PR DESCRIPTION
`readSDMX` currently doesn't seem to explicitly check the status of the response from `getURL`. As a result, it gives nonsensical error messages if something goes wrong with the HTTP request. For example, I was using an old proxy password in my `RCurlOptions` and kept getting this error message: 

```
> library(rsdmx)
> myUrl <- "http://stats.oecd.org/restsdmx/sdmx.ashx/GetData/MIG/TOT../OECD?startTime=2000&endTime=2011"
> dataset <- readSDMX(myUrl)
Opening and ending tag mismatch: META line 2 and HEAD
Specification mandate value for attribute noshade
attributes construct error
Couldn't find end of Start Tag HR line 9
Opening and ending tag mismatch: LI line 16 and UL
Opening and ending tag mismatch: UL line 15 and P
Opening and ending tag mismatch: A line 31 and a
Opening and ending tag mismatch: A line 33 and a
Specification mandate value for attribute noshade
attributes construct error
Couldn't find end of Start Tag HR line 37
... (truncated)
```

This made it difficult to debug and realize that it was a problem with the proxy. With the suggested change, the error message is instead:

```
> library(rsdmx)
> myUrl <- "http://stats.oecd.org/restsdmx/sdmx.ashx/GetData/MIG/TOT../OECD?startTime=2000&endTime=2011"
> dataset <- readSDMX(myUrl)
Error in readSDMX(myUrl) : 
  HTTP request failed with status: 407 Proxy Authentication Required
```