### PR TITLE
Header parameter

### DIFF
--- a/R/Class-SDMXRequestBuilder.R
+++ b/R/Class-SDMXRequestBuilder.R
@@ -16,6 +16,8 @@
 #' @slot compliant an object of class "logical" indicating if the request builder is somehow compliant with a service specification 
 #' @slot unsupportedResources an object of class "character" giving one or more resources not
 #'       supported by the Request builder for a given provider
+#' @slot header an object of class "list" that contains any additional headers for the request.
+
 #'
 #' @section Warning:
 #' This class is not useful in itself, but all SDMX non-abstract classes will 
@@ -32,7 +34,8 @@ setClass("SDMXRequestBuilder",
            formatter = "list",
            handler = "list",
            compliant = "logical",
-           unsupportedResources = "list"
+           unsupportedResources = "list",
+           header = "list"
          ),
          prototype = list(
            regUrl = "http://www.myorg.org/sdmx/registry",
@@ -49,7 +52,8 @@ setClass("SDMXRequestBuilder",
               "data" = function(obj){return(obj@repoUrl)}
            ),
            compliant = TRUE,
-           unsupportedResources = list()
+           unsupportedResources = list(),
+           header = list()
          ),
          validity = function(object){
            

--- a/R/Class-SDMXRequestBuilder.R
+++ b/R/Class-SDMXRequestBuilder.R
@@ -16,7 +16,7 @@
 #' @slot compliant an object of class "logical" indicating if the request builder is somehow compliant with a service specification 
 #' @slot unsupportedResources an object of class "character" giving one or more resources not
 #'       supported by the Request builder for a given provider
-#' @slot header an object of class "list" that contains any additional headers for the request.
+#' @slot headers an object of class "list" that contains any additional headers for the request.
 
 #'
 #' @section Warning:
@@ -35,7 +35,7 @@ setClass("SDMXRequestBuilder",
            handler = "list",
            compliant = "logical",
            unsupportedResources = "list",
-           header = "list"
+           headers = "list"
          ),
          prototype = list(
            regUrl = "http://www.myorg.org/sdmx/registry",
@@ -53,7 +53,7 @@ setClass("SDMXRequestBuilder",
            ),
            compliant = TRUE,
            unsupportedResources = list(),
-           header = list()
+           headers = list()
          ),
          validity = function(object){
            

--- a/R/SDMXDotStatRequestBuilder-methods.R
+++ b/R/SDMXDotStatRequestBuilder-methods.R
@@ -30,8 +30,9 @@
 #'     repoUrl = "http://www.myorg/repository")
 #'
 SDMXDotStatRequestBuilder <- function(regUrl, repoUrl, accessKey = NULL,
-                                   unsupportedResources = list(),
-                                   skipProviderId = FALSE, forceProviderId = FALSE){    
+                                   unsupportedResources = list(), 
+                                   skipProviderId = FALSE, forceProviderId = FALSE,
+                                   headers = list()){    
 
   #params formatter
   formatter = list(
@@ -137,7 +138,8 @@ SDMXDotStatRequestBuilder <- function(regUrl, repoUrl, accessKey = NULL,
       formatter = formatter,
       handler = handler,
       compliant = FALSE,
-      unsupportedResources = unsupportedResources)
+      unsupportedResources = unsupportedResources,
+      headers = headers)
 }
 
 

--- a/R/SDMXREST20RequestBuilder-methods.R
+++ b/R/SDMXREST20RequestBuilder-methods.R
@@ -32,7 +32,7 @@
 #'     repoUrl = "http://www.myorg/repository", compliant = FALSE)
 #'
 SDMXREST20RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, compliant,
-                                     unsupportedResources = list(),
+                                     unsupportedResources = list(), header = header(),
                                      skipProviderId = FALSE, forceProviderId = FALSE){
     
   #params formatter
@@ -130,7 +130,8 @@ SDMXREST20RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, complian
       formatter = formatter,
       handler = handler,
       compliant = compliant,
-      unsupportedResources = unsupportedResources)
+      unsupportedResources = unsupportedResources,
+      header = header)
 }
 
 

--- a/R/SDMXREST20RequestBuilder-methods.R
+++ b/R/SDMXREST20RequestBuilder-methods.R
@@ -32,8 +32,9 @@
 #'     repoUrl = "http://www.myorg/repository", compliant = FALSE)
 #'
 SDMXREST20RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, compliant,
-                                     unsupportedResources = list(), header = list(),
-                                     skipProviderId = FALSE, forceProviderId = FALSE){
+                                     unsupportedResources = list(), 
+                                     skipProviderId = FALSE, forceProviderId = FALSE,
+                                     headers = list()){
     
   #params formatter
   formatter = list(
@@ -131,7 +132,7 @@ SDMXREST20RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, complian
       handler = handler,
       compliant = compliant,
       unsupportedResources = unsupportedResources,
-      header = header)
+      headers = headers)
 }
 
 

--- a/R/SDMXREST20RequestBuilder-methods.R
+++ b/R/SDMXREST20RequestBuilder-methods.R
@@ -32,7 +32,7 @@
 #'     repoUrl = "http://www.myorg/repository", compliant = FALSE)
 #'
 SDMXREST20RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, compliant,
-                                     unsupportedResources = list(), header = header(),
+                                     unsupportedResources = list(), header = list(),
                                      skipProviderId = FALSE, forceProviderId = FALSE){
     
   #params formatter

--- a/R/SDMXREST21RequestBuilder-methods.R
+++ b/R/SDMXREST21RequestBuilder-methods.R
@@ -33,7 +33,7 @@
 #'     compliant = TRUE)
 #'
 SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, compliant,
-                                     unsupportedResources = list(),
+                                     unsupportedResources = list(), header = list(),
                                      skipProviderId = FALSE, forceProviderId = FALSE){
   
   #params formatter
@@ -144,5 +144,6 @@ SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, complian
       formatter = formatter,
       handler = handler,
       compliant = compliant,
-      unsupportedResources = unsupportedResources)
+      unsupportedResources = unsupportedResources,
+      header = header)
 }

--- a/R/SDMXREST21RequestBuilder-methods.R
+++ b/R/SDMXREST21RequestBuilder-methods.R
@@ -33,8 +33,9 @@
 #'     compliant = TRUE)
 #'
 SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, compliant,
-                                     unsupportedResources = list(), header = list(),
-                                     skipProviderId = FALSE, forceProviderId = FALSE){
+                                     unsupportedResources = list(), 
+                                     skipProviderId = FALSE, forceProviderId = FALSE,
+                                     headers = list()){
   
   #params formatter
   formatter = list(
@@ -145,5 +146,5 @@ SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, complian
       handler = handler,
       compliant = compliant,
       unsupportedResources = unsupportedResources,
-      header = header)
+      headers = headers)
 }

--- a/R/SDMXRequestBuilder-methods.R
+++ b/R/SDMXRequestBuilder-methods.R
@@ -17,6 +17,7 @@
 #' @param compliant an object of class "logical" indicating if the request builder is somehow compliant with a service specification
 #' @param unsupportedResources an object of class "list" giving one or more resources not
 #'        supported by the Request builder for a given provider
+#' @param header an object of class "list" that contains headers for the web request
 #' 
 #' @details
 #' The \code{handler} function will list the resource methods. Each method will accept a
@@ -66,10 +67,10 @@
 #'
 SDMXRequestBuilder <- function(regUrl, repoUrl, accessKey = NULL,
                                formatter, handler, compliant,
-                               unsupportedResources = list()){
+                               unsupportedResources = list(), header = list()){
   
   new("SDMXRequestBuilder",
       regUrl = regUrl, repoUrl = repoUrl, accessKey = accessKey,
       formatter = formatter, handler = handler, compliant = compliant,
-      unsupportedResources = unsupportedResources)
+      unsupportedResources = unsupportedResources, header = header)
 }

--- a/R/SDMXRequestBuilder-methods.R
+++ b/R/SDMXRequestBuilder-methods.R
@@ -17,7 +17,7 @@
 #' @param compliant an object of class "logical" indicating if the request builder is somehow compliant with a service specification
 #' @param unsupportedResources an object of class "list" giving one or more resources not
 #'        supported by the Request builder for a given provider
-#' @param header an object of class "list" that contains headers for the web request
+#' @param headers an object of class "list" that contains headers for the web request
 #' 
 #' @details
 #' The \code{handler} function will list the resource methods. Each method will accept a
@@ -67,10 +67,10 @@
 #'
 SDMXRequestBuilder <- function(regUrl, repoUrl, accessKey = NULL,
                                formatter, handler, compliant,
-                               unsupportedResources = list(), header = list()){
+                               unsupportedResources = list(), headers = list()){
   
   new("SDMXRequestBuilder",
       regUrl = regUrl, repoUrl = repoUrl, accessKey = accessKey,
       formatter = formatter, handler = handler, compliant = compliant,
-      unsupportedResources = unsupportedResources, header = header)
+      unsupportedResources = unsupportedResources, headers = headers)
 }

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -55,7 +55,7 @@
 #' @param verbose an Object of class "logical" that indicates if rsdmx messages should
 #'        appear to user. Default is TRUE.
 #' 
-#' @param header an object of class "list" that contains any additional headers for the request.
+#' @param headers an object of class "list" that contains any additional headers for the request.
 #' 
 #' @return an object of class "SDMX"
 #' 
@@ -131,7 +131,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                      provider = NULL, providerId = NULL, providerKey = NULL,
                      agencyId = NULL, resource = NULL, resourceId = NULL, version = NULL,
                      flowRef = NULL, key = NULL, key.mode = "R", start = NULL, end = NULL, dsd = FALSE,
-                     validate = FALSE, verbose = TRUE, header = NULL) {
+                     validate = FALSE, verbose = TRUE, headers = NULL) {
   
   #set option for SDMX compliance validation
   .rsdmx.options$validate <- validate
@@ -225,7 +225,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
     requestURL <- function(file){
       rsdmxAgent <- paste("rsdmx/",as.character(packageVersion("rsdmx")),sep="")
       h <- RCurl::basicHeaderGatherer()
-      content <- RCurl::getURL(file, httpheader = c('User-Agent' = rsdmxAgent, header),
+      content <- RCurl::getURL(file, httpheader = c('User-Agent' = rsdmxAgent, headers),
                       ssl.verifypeer = FALSE, .encoding = "UTF-8",
                       encoding = "gzip", headerfunction = h$update)
       return(list(response = content, header = h$value()));

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -55,6 +55,8 @@
 #' @param verbose an Object of class "logical" that indicates if rsdmx messages should
 #'        appear to user. Default is TRUE.
 #' 
+#' @param header an object of class "list" that contains any additional headers for the request.
+#' 
 #' @return an object of class "SDMX"
 #' 
 #' @examples             
@@ -129,7 +131,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                      provider = NULL, providerId = NULL, providerKey = NULL,
                      agencyId = NULL, resource = NULL, resourceId = NULL, version = NULL,
                      flowRef = NULL, key = NULL, key.mode = "R", start = NULL, end = NULL, dsd = FALSE,
-                     validate = FALSE, verbose = TRUE) {
+                     validate = FALSE, verbose = TRUE, header = NULL) {
   
   #set option for SDMX compliance validation
   .rsdmx.options$validate <- validate
@@ -223,7 +225,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
     requestURL <- function(file){
       rsdmxAgent <- paste("rsdmx/",as.character(packageVersion("rsdmx")),sep="")
       h <- RCurl::basicHeaderGatherer()
-      content <- RCurl::getURL(file, httpheader = list('User-Agent' = rsdmxAgent),
+      content <- RCurl::getURL(file, httpheader = c('User-Agent' = rsdmxAgent, header),
                       ssl.verifypeer = FALSE, .encoding = "UTF-8",
                       encoding = "gzip", headerfunction = h$update)
       return(list(response = content, header = h$value()));


### PR DESCRIPTION
Added optional header parameter to readSDMX function. 
Example:

```
sdmx <- readSDMX(providerId = "ABSBETA",
                 resource = "data",
                 header = list(`x-api-key` = api_key),
                 flowRef="RES_DWELL",
                 key = "all",
                 key.mode = "SDMX",
                 start = 2000, end = 2015)```