### PR TITLE
Remove STAT_EE and update tests

### DIFF
--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -557,7 +557,7 @@ setSDMXServiceProviders <- function(){ # nocov start
     #international
     BIS, ECB, ESTAT,ESTAT_COMEXT, ESTAT_COMP, ESTAT_GROW, ESTAT_EMPL, IMF, IMF_DATA, OECD, UNICEF, CD2030, UNSD, ILO_Legacy, ILO, WBG_WITS, WB, PDH,
     #national
-    ABS, NBB, INSEE, INEGI, ISTAT_LEGACY, ISTAT, NOMIS, LSD, NCSI, STAT_EE, BBK,
+    ABS, NBB, INSEE, INEGI, ISTAT_LEGACY, ISTAT, NOMIS, LSD, NCSI, BBK,
     #others
     KNOEMA
   )

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -430,17 +430,6 @@ setSDMXServiceProviders <- function(){ # nocov start
     )
   )
   
-  #STAT_EE - Statistics Estonia database {Estonia}
-  STAT_EE <- SDMXServiceProvider(
-    agencyId = "STAT_EE", name = "Statistics Estonia database",
-    scale = "national", country = "EST",
-    builder = SDMXDotStatRequestBuilder(
-      regUrl = "http://andmebaas.stat.ee/restsdmx/sdmx.ashx",
-      repoUrl = "http://andmebaas.stat.ee/restsdmx/sdmx.ashx",
-      unsupportedResources = list("dataflow")
-    )
-  )
-  
   #UKDS removed - no support for SDMX-JSON in rsdmx at now
   #UKDS <- SDMXServiceProvider(
   #  agencyId = "UKDS", name = "United Kingdom Data Service",

--- a/tests/testthat/test_Main.R
+++ b/tests/testthat/test_Main.R
@@ -78,22 +78,24 @@ test_that("readSDMX - SDMXDataStructureDefinition (DSD) - 2.0",{
   expect_is(dsd@datastructures, "SDMXDataStructures")
 })
 
-test_that("readSDMX - Catch 400 bad request", {
+test_that("readSDMX - Catch 404 bad request", {
   testthat::skip_on_travis()
   testthat::skip_on_cran()
   expect_error(
-    sdmx <- readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "bad_ref")
+    sdmx <- readSDMX(providerId = "OECD", resource = "data", flowRef = "bad_ref"),
+    "HTTP request failed with status: 404"
   )
 })
 
-test_that("readSDMX - Catch good request that fails for other reason (bad proxy)", {
-  testthat::skip_on_travis()
-  testthat::skip_on_cran()
-  old_opts <- options()
-  options(RCurlOptions = list("proxy" = "bad_proxy"))
-  
-  expect_error(
-    sdmx <- readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "SADG2015")
-  )
-  options(old_opts)
-})
+# Knoema is failing with 502 regardless of proxt settings
+#test_that("readSDMX - Catch good request that fails for other reason (bad proxy)", {
+#  testthat::skip_on_travis()
+#  testthat::skip_on_cran()
+#  old_opts <- options()
+#  options(RCurlOptions = list("proxy" = "bad_proxy"))
+#  
+#  expect_error(
+#    sdmx <- readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "SADG2015")
+#  )
+#  options(old_opts)
+#})

--- a/tests/testthat/test_Main.R
+++ b/tests/testthat/test_Main.R
@@ -87,7 +87,7 @@ test_that("readSDMX - Catch 404 bad request", {
   )
 })
 
-# Knoema is failing with 502 regardless of proxt settings
+# Knoema is failing with 502 regardless of proxy settings
 #test_that("readSDMX - Catch good request that fails for other reason (bad proxy)", {
 #  testthat::skip_on_travis()
 #  testthat::skip_on_cran()

--- a/tests/testthat/test_Main_Helpers.R
+++ b/tests/testthat/test_Main_Helpers.R
@@ -31,8 +31,7 @@ test_that("Main helpers arguments",{
   expect_error(readSDMX(providerId = providerId2, resource = "dataflow"), "No provider with identifier IMF!")
   
   #wrong request
-  expect_error(readSDMX(providerId = "KNOEMA", resource = "data", flowRef = "SADG2015-WRONG"),
-               "HTTP request failed with status: 400 ")
+  expect_error(readSDMX(providerId = "OECD", resource = "data", flowRef = "SADG2015-WRONG"))
   
 })
 

--- a/tests/testthat/test_Main_Helpers.R
+++ b/tests/testthat/test_Main_Helpers.R
@@ -192,7 +192,7 @@ test_that("OECD - data",{
   sdmx <- readSDMX(providerId = "OECD", resource = "data", flowRef = "DSD_PRICES@DF_PRICES_N_CP01",
                    key = list("GRC", NULL, NULL, NULL, NULL, NULL, NULL, NULL), start = 2020, end = 2020)
   if(!is.null(sdmx)){
-    expect_is(sdmx, "SDMXMessageGroup")
+    expect_is(sdmx, "SDMXGenericData")
   }
 })
 

--- a/tests/testthat/test_Main_Helpers.R
+++ b/tests/testthat/test_Main_Helpers.R
@@ -704,29 +704,6 @@ test_that("NCSI - datastructure",{
 #  }
 #})
 
-#STAT_E (Estonia)
-#-------------
-
-#-> datastructure
-test_that("STAT_EE - datastructure",{
-  testthat::skip_on_cran()
-  sdmx <- readSDMX(providerId = "STAT_EE", resource = "datastructure", resourceId = "KK11")
-  if(!is.null(sdmx)){
-    expect_is(sdmx, "SDMXDataStructureDefinition")
-  }
-})
-
-#-> data
-test_that("STAT_EE - data",{
-  testthat::skip_on_cran()
-  sdmx <- readSDMX(providerId = "STAT_EE", resource = "data",
-                   flowRef = "KK11", key = "all", key.mode = "SDMX",
-                   start = "2015", end = "2015")
-  if(!is.null(sdmx)){
-    expect_is(sdmx, "SDMXMessageGroup")
-  }
-})
-
 
 #BBK (Bundesbank)
 #-------------


### PR DESCRIPTION
Removing STAT_EE as a provider as they no longer produce an SDMX API.

Repointing KNOEMA tests at OECD so they do not time out.

Commenting out bad proxy test, as KNOEMA is failing with or without bad proxy. Could not find another provider which would fail from the proxy settings.

Updating message type for OECD based on their new API.

This resolves: https://github.com/opensdmx/rsdmx/issues/207 and https://github.com/opensdmx/rsdmx/issues/208