### PR TITLE
Add references to request parameters and support dsd=true for source who use core representations for their concepts

### DIFF
--- a/R/Class-SDMXDimension.R
+++ b/R/Class-SDMXDimension.R
@@ -38,6 +38,7 @@ setClass("SDMXDimension",
           conceptVersion = "character", #optional
           conceptAgency = "character", #optional
           conceptSchemeRef = "character", #optional
+          conceptSchemeVersion = "character", #optional
           conceptSchemeAgency = "character", #optional
           codelist = "character", #optional
           codelistVersion = "character", #optional
@@ -63,6 +64,7 @@ setClass("SDMXDimension",
           conceptVersion = "1.0",
           conceptAgency = "ORG",
           conceptSchemeRef = "CONCEPT_SCHEME",
+          conceptSchemeVersion = "1.0",
           conceptSchemeAgency = "ORG",
           codelist = "CODELIST",
           codelistVersion = "1.0",

--- a/R/Class-SDMXRequestParams.R
+++ b/R/Class-SDMXRequestParams.R
@@ -17,7 +17,8 @@
 #' @slot flowRef an object of class "character" giving the flowRef to be queried
 #' @slot key an object of class "character" giving the key (SDMX url formatted) to be used for the query
 #' @slot start an object of class "character" giving the start time
-#' @slot end an object of class "character" giving the end time
+#' @slot end an object of class "character" giving the end time 
+#' @slot references an object of class "character" giving the instructions to return (or not) the artefacts referenced by the artefact to be returned
 #' @slot compliant an object of class "logical" indicating if the web-service is compliant with the SDMX REST web-service specifications
 #'
 #' @section Warning:
@@ -40,6 +41,7 @@ setClass("SDMXRequestParams",
            key = "character_OR_NULL",
            start = "character_OR_numeric_OR_NULL",
            end = "character_OR_numeric_OR_NULL",
+           references = "character_OR_NULL",
            compliant = "logical"
            ),
          prototype = list(),

--- a/R/SDMXConcepts-methods.R
+++ b/R/SDMXConcepts-methods.R
@@ -40,6 +40,11 @@ concepts.SDMXConcepts <- function(xmlObj, namespaces){
                               "//mes:Structures/str:Concepts/str:Concept",
                               namespaces = c(mes = as.character(messageNs),
                                              str = as.character(strNs)))
+    conceptsXML <- c(conceptsXML,
+                    getNodeSet(xmlObj,
+                              "//mes:Structures/str:Concepts/str:ConceptScheme/str:Concept",
+                              namespaces = c(mes = as.character(messageNs),
+                                             str = as.character(strNs))))
   }else{
     conceptsXML <- getNodeSet(xmlObj,
                               "//mes:Concepts/str:Concept",

--- a/R/SDMXDimension-methods.R
+++ b/R/SDMXDimension-methods.R
@@ -130,6 +130,7 @@ SDMXDimension <- function(xmlObj, namespaces){
   if(is.null(conceptVersion)) conceptVersion <- as.character(NA)
   if(is.null(conceptAgency)) conceptAgency <- as.character(NA)
   if(is.null(conceptSchemeRef)) conceptSchemeRef <- as.character(NA)
+  if(is.null(conceptSchemeVersion)) conceptSchemeVersion <- as.character(NA)
   if(is.null(conceptSchemeAgency)) conceptSchemeAgency <- as.character(NA)
   
   if(is.null(codelist)) codelist <- as.character(NA)

--- a/R/SDMXDimension-methods.R
+++ b/R/SDMXDimension-methods.R
@@ -45,6 +45,7 @@ SDMXDimension <- function(xmlObj, namespaces){
   conceptVersion <- NULL
   conceptAgency <- NULL
   conceptSchemeRef <- NULL
+  conceptSchemeVersion <- NULL
   conceptSchemeAgency <- NULL
   codelist <- NULL
   codelistVersion <- NULL
@@ -64,10 +65,16 @@ SDMXDimension <- function(xmlObj, namespaces){
     #concepts
     if(!is.null(conceptRefXML)){
       conceptRef = xmlGetAttr(conceptRefXML, "id")
-      conceptVersion = xmlGetAttr(conceptRefXML, "maintainableParentVersion")
-      conceptAgency = xmlGetAttr(conceptRefXML, "agencyID")
-      #TODO conceptSchemeRef?
-      #TODO conceptSchemeAgency
+      package = xmlGetAttr(conceptRefXML, "package")
+      if(package == "conceptscheme"){
+        conceptSchemeRef = xmlGetAttr(conceptRefXML, "maintainableParentID")
+        conceptSchemeVersion = xmlGetAttr(conceptRefXML, "maintainableParentVersion") 
+        conceptSchemeAgency = xmlGetAttr(conceptRefXML, "agencyID")
+      }else{
+        conceptVersion = xmlGetAttr(conceptRefXML, "maintainableParentVersion")
+        conceptAgency = xmlGetAttr(conceptRefXML, "agencyID")
+      }
+
     }
     
     #codelists
@@ -201,6 +208,7 @@ SDMXDimension <- function(xmlObj, namespaces){
             conceptVersion = conceptVersion,
             conceptAgency = conceptAgency,
             conceptSchemeRef = conceptSchemeRef,
+            conceptSchemeVersion = conceptSchemeVersion,
             conceptSchemeAgency = conceptSchemeAgency,
             codelist = codelist,
             codelistVersion = codelistVersion,

--- a/R/SDMXREST21RequestBuilder-methods.R
+++ b/R/SDMXREST21RequestBuilder-methods.R
@@ -82,7 +82,8 @@ SDMXREST21RequestBuilder <- function(regUrl, repoUrl, accessKey = NULL, complian
       if(is.null(obj@version)) obj@version = "latest"
       req <- sprintf("%s/datastructure/%s/%s/%s/",obj@regUrl, obj@agencyId, obj@resourceId, obj@version)
       if(forceProviderId) req <- paste(req, obj@providerId, sep = "/")
-      req <- paste0(req, "?references=children") #TODO to see later to have arg for this
+      if(is.null(obj@references)) obj@references = "children"
+      req <- paste0(req, "?references=", obj@references)
       
       #require key
       if(!is.null(accessKey)){

--- a/R/SDMXRequestParams-methods.R
+++ b/R/SDMXRequestParams-methods.R
@@ -29,7 +29,7 @@
 #'   params <- SDMXRequestParams(
 #'    regUrl = "", repoUrl ="", accessKey = NULL,
 #'    providerId = "", agencyId ="", resource = "data", resourceId = "",
-#'    version = "", flowRef = "", key = NULL, start = NULL, end = NULL, compliant = FALSE
+#'    version = "", flowRef = "", key = NULL, start = NULL, end = NULL, references = NULL, compliant = FALSE
 #'   )
 #' @export
 #' 

--- a/R/SDMXRequestParams-methods.R
+++ b/R/SDMXRequestParams-methods.R
@@ -21,6 +21,7 @@
 #' @param key an object of class "character" giving the key (SDMX url formatted) to be used for the query
 #' @param start an object of class "character" giving the start time
 #' @param end an object of class "character" giving the end time
+#' @param references an object of class "character" giving the instructions to return (or not) the artefacts referenced by the artefact to be returned
 #' @param compliant an object of class "logical" indicating if the web-service is compliant with the SDMX REST web-service specifications
 #'             
 #' @examples
@@ -33,10 +34,10 @@
 #' @export
 #' 
 SDMXRequestParams <- function(regUrl, repoUrl, accessKey, providerId, agencyId, resource, resourceId, version = NULL,
-                              flowRef, key = NULL, start = NULL, end = NULL, compliant){
+                              flowRef, key = NULL, start = NULL, end = NULL, references = NULL, compliant){
   new("SDMXRequestParams",
       regUrl = regUrl, repoUrl = repoUrl, accessKey = accessKey, providerId = providerId,
        agencyId = agencyId, resource = resource, resourceId = resourceId, version = version,
-       flowRef = flowRef, key = key, start = start, end = end)
+       flowRef = flowRef, key = key, start = start, end = end, references = references)
 }
 

--- a/R/SDMXRequestParams-methods.R
+++ b/R/SDMXRequestParams-methods.R
@@ -5,7 +5,7 @@
 #' @usage
 #'  SDMXRequestParams(regUrl, repoUrl, accessKey,
 #'                    providerId, agencyId, resource, resourceId, version,
-#'                    flowRef, key, start, end, compliant)
+#'                    flowRef, key, start, end, references = NULL, compliant)
 #'
 #' @param regUrl an object of class "character" giving the base Url of the SDMX service registry
 #' @param repoUrl an object of class "character" giving the base Url of the SDMX service repository

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -168,7 +168,6 @@ setSDMXServiceProviders <- function(){ # nocov start
     builder = SDMXREST21RequestBuilder(
       regUrl = "https://api.imf.org/external/sdmx/2.1",
       repoUrl = "https://api.imf.org/external/sdmx/2.1",
-      references = "descendants",
       compliant = TRUE)
   )
     

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -168,6 +168,7 @@ setSDMXServiceProviders <- function(){ # nocov start
     builder = SDMXREST21RequestBuilder(
       regUrl = "https://api.imf.org/external/sdmx/2.1",
       repoUrl = "https://api.imf.org/external/sdmx/2.1",
+      references = "descendants",
       compliant = TRUE)
   )
     

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -168,7 +168,10 @@ setSDMXServiceProviders <- function(){ # nocov start
     builder = SDMXREST21RequestBuilder(
       regUrl = "https://api.imf.org/external/sdmx/2.1",
       repoUrl = "https://api.imf.org/external/sdmx/2.1",
-      compliant = TRUE)
+      compliant = TRUE,
+      formatter$datastructure = function(obj){
+        if(is.null(obj@references)) obj@references = "descendants"
+        return(obj)})
   )
     
   #OECD

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -175,6 +175,7 @@ setSDMXServiceProviders <- function(){ # nocov start
           return(obj)
         }
       )
+    )
   )
     
   #OECD

--- a/R/SDMXServiceProvider-methods.R
+++ b/R/SDMXServiceProvider-methods.R
@@ -169,9 +169,12 @@ setSDMXServiceProviders <- function(){ # nocov start
       regUrl = "https://api.imf.org/external/sdmx/2.1",
       repoUrl = "https://api.imf.org/external/sdmx/2.1",
       compliant = TRUE,
-      formatter$datastructure = function(obj){
-        if(is.null(obj@references)) obj@references = "descendants"
-        return(obj)})
+      formatter = list(
+        datastructure = function(obj){
+          if(is.null(obj@references)) obj@references = "descendants"
+          return(obj)
+        }
+      )
   )
     
   #OECD

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -208,6 +208,14 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                        references = references,
                        compliant = provider@builder@compliant
                      )
+    
+    #allow IMF requests to 
+    if(providerId == "IMF_DATA"){
+      if is.null(references){
+        requestParams@references <- "descendants"
+      }
+    }
+
     #formatting requestParams
     requestFormatter <- provider@builder@formatter
     requestParams <- switch(resource,
@@ -453,15 +461,10 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
       }
       
       if(resource == "data"){
-        #if(providerId == "IMF_DATA"){
-        #  dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
-        #                    resource = "datastructure", resourceId = dsdRef, headers = headers,
-        #                    verbose = verbose, references = "descendants", logger = logger, ...)
-        #}else{
         dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
                           resource = "datastructure", resourceId = dsdRef, headers = headers,
-                          verbose = verbose, logger = logger, ...)
-        #}
+                          verbose = verbose, references = references, logger = logger, ...)
+
 
         if(is.null(dsdObj)){
           log$WARN(sprintf("Impossible to fetch DSD for dataset '%s'", flowRef))
@@ -473,7 +476,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
         dsdObj <- lapply(1:length(dsdRef), function(x){
           flowDsd <- readSDMX(providerId = providerId, providerKey = providerKey,
                               resource = "datastructure", resourceId = dsdRef[[x]], headers = headers,
-                              verbose = verbose, logger = logger, ...)
+                              verbose = verbose, references = references, logger = logger, ...)
           if(is.null(flowDsd)){
             log$INFO(sprintf("Impossible to fetch DSD for dataflow '%s'",resourceId))
           }else{

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -7,7 +7,7 @@
 #'   provider = NULL, providerId = NULL, providerKey = NULL,
 #'   agencyId = NULL, resource = NULL, resourceId = NULL, version = NULL,
 #'   flowRef = NULL, key = NULL, key.mode = "R", start = NULL, end = NULL, dsd = FALSE,
-#'   headers = list(), validate = FALSE,
+#'   headers = list(), validate = FALSE, references = NULL,
 #'   verbose = !is.null(logger), logger = "INFO", ...)
 #'                 
 #' @param file path to SDMX-ML document that needs to be parsed

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -208,13 +208,6 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                        references = references,
                        compliant = provider@builder@compliant
                      )
-    
-    #allow IMF requests to use descendants instead of children
-    if(providerId == "IMF_DATA"){
-      if(is.null(references)){
-        requestParams@references <- "descendants"
-      }
-    }
 
     #formatting requestParams
     requestFormatter <- provider@builder@formatter

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -453,15 +453,15 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
       }
       
       if(resource == "data"){
-        if(providerId == "IMF_DATA"){
-          dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
-                            resource = "datastructure", resourceId = dsdRef, headers = headers,
-                            verbose = verbose, references = "descendants", logger = logger, ...)
-        }else{
-          dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
-                            resource = "datastructure", resourceId = dsdRef, headers = headers,
-                            verbose = verbose, logger = logger, ...)
-        }
+        #if(providerId == "IMF_DATA"){
+        #  dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
+        #                    resource = "datastructure", resourceId = dsdRef, headers = headers,
+        #                    verbose = verbose, references = "descendants", logger = logger, ...)
+        #}else{
+        dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
+                          resource = "datastructure", resourceId = dsdRef, headers = headers,
+                          verbose = verbose, logger = logger, ...)
+        #}
 
         if(is.null(dsdObj)){
           log$WARN(sprintf("Impossible to fetch DSD for dataset '%s'", flowRef))

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -453,10 +453,10 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
       }
       
       if(resource == "data"){
-        if providerId == "IMF_DATA"{
+        if(providerId == "IMF_DATA"){
           dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
-                    resource = "datastructure", resourceId = dsdRef, headers = headers,
-                    verbose = verbose, references = "descendants", logger = logger, ...)
+                            resource = "datastructure", resourceId = dsdRef, headers = headers,
+                            verbose = verbose, references = "descendants", logger = logger, ...)
         }else{
           dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
                             resource = "datastructure", resourceId = dsdRef, headers = headers,

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -211,7 +211,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
     
     #allow IMF requests to 
     if(providerId == "IMF_DATA"){
-      if is.null(references){
+      if(is.null(references)){
         requestParams@references <- "descendants"
       }
     }

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -209,7 +209,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                        compliant = provider@builder@compliant
                      )
     
-    #allow IMF requests to 
+    #allow IMF requests to use descendants instead of children
     if(providerId == "IMF_DATA"){
       if(is.null(references)){
         requestParams@references <- "descendants"

--- a/R/readSDMX.R
+++ b/R/readSDMX.R
@@ -48,6 +48,8 @@
 #'        Recognized if a valid provider or provide id has been specified as argument.
 #' @param end an object of class "integer" or "character" giving the SDMX end time to apply. 
 #'        Recognized if a valid provider or provide id has been specified as argument.
+#' @param references an object of class "character" giving the instructions to return (or not) the
+#'        artefacts referenced by the artefact to be returned.
 #' @param dsd an Object of class "logical" if an attempt to inherit the DSD should be performed.
 #'        Active only if \code{"readSDMX"} is used as helper method (ie if data is fetched using 
 #'        an embedded service provider. Default is FALSE
@@ -138,7 +140,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                      provider = NULL, providerId = NULL, providerKey = NULL,
                      agencyId = NULL, resource = NULL, resourceId = NULL, version = NULL,
                      flowRef = NULL, key = NULL, key.mode = "R", start = NULL, end = NULL, dsd = FALSE,
-                     headers = list(), validate = FALSE,
+                     headers = list(), validate = FALSE, references = NULL,
                      verbose = !is.null(logger), logger = "INFO", ...) {
   
   #logger
@@ -203,6 +205,7 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
                        key = key,
                        start = start,
                        end = end,
+                       references = references,
                        compliant = provider@builder@compliant
                      )
     #formatting requestParams
@@ -450,9 +453,16 @@ readSDMX <- function(file = NULL, isURL = TRUE, isRData = FALSE,
       }
       
       if(resource == "data"){
-        dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
-                           resource = "datastructure", resourceId = dsdRef, headers = headers,
-                           verbose = verbose, logger = logger, ...)
+        if providerId == "IMF_DATA"{
+          dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
+                    resource = "datastructure", resourceId = dsdRef, headers = headers,
+                    verbose = verbose, references = "descendants", logger = logger, ...)
+        }else{
+          dsdObj <- readSDMX(providerId = providerId, providerKey = providerKey,
+                            resource = "datastructure", resourceId = dsdRef, headers = headers,
+                            verbose = verbose, logger = logger, ...)
+        }
+
         if(is.null(dsdObj)){
           log$WARN(sprintf("Impossible to fetch DSD for dataset '%s'", flowRef))
         }else{

--- a/man/SDMXRequestParams.Rd
+++ b/man/SDMXRequestParams.Rd
@@ -10,7 +10,7 @@
 \usage{
 SDMXRequestParams(regUrl, repoUrl, accessKey,
                    providerId, agencyId, resource, resourceId, version,
-                   flowRef, key, start, end, compliant)
+                   flowRef, key, start, end, references = NULL, compliant)
 }
 \arguments{
 \item{regUrl}{an object of class "character" giving the base Url of the SDMX service registry}

--- a/man/SDMXRequestParams.Rd
+++ b/man/SDMXRequestParams.Rd
@@ -39,6 +39,8 @@ mandatory for some service providers.}
 
 \item{end}{an object of class "character" giving the end time}
 
+\item{references}{an object of class "character" giving the instructions to return (or not) the artefacts referenced by the artefact to be returned}
+
 \item{compliant}{an object of class "logical" indicating if the web-service is compliant with the SDMX REST web-service specifications}
 }
 \description{
@@ -71,6 +73,8 @@ an authentication or subscription user key/token has to be provided to perform r
 \item{\code{start}}{an object of class "character" giving the start time}
 
 \item{\code{end}}{an object of class "character" giving the end time}
+
+\item{\code{references}}{an object of class "character" giving the instructions to return (or not) the artefacts referenced by the artefact to be returned}
 
 \item{\code{compliant}}{an object of class "logical" indicating if the web-service is compliant with the SDMX REST web-service specifications}
 }}

--- a/man/SDMXRequestParams.Rd
+++ b/man/SDMXRequestParams.Rd
@@ -90,7 +90,7 @@ encapsulate it as slot, when parsing an SDMX-ML document.
   params <- SDMXRequestParams(
    regUrl = "", repoUrl ="", accessKey = NULL,
    providerId = "", agencyId ="", resource = "data", resourceId = "",
-   version = "", flowRef = "", key = NULL, start = NULL, end = NULL, compliant = FALSE
+   version = "", flowRef = "", key = NULL, start = NULL, end = NULL, references = NULL, compliant = FALSE
   )
 }
 \author{

--- a/man/readSDMX.Rd
+++ b/man/readSDMX.Rd
@@ -75,6 +75,9 @@ an embedded service provider. Default is FALSE}
 be performed on the SDMX-ML document to check its SDMX compliance when reading it.
 Default is FALSE.}
 
+\item{references}{an object of class "character" giving the instructions to return (or not) the
+artefacts referenced by the artefact to be returned.}
+
 \item{verbose}{an Object of class "logical" that indicates if rsdmx logs should
 appear to user. Default is set to \code{FALSE} (see argument \code{logger}).}
 

--- a/man/readSDMX.Rd
+++ b/man/readSDMX.Rd
@@ -8,7 +8,7 @@ readSDMX(file = NULL, isURL = TRUE, isRData = FALSE,
   provider = NULL, providerId = NULL, providerKey = NULL,
   agencyId = NULL, resource = NULL, resourceId = NULL, version = NULL,
   flowRef = NULL, key = NULL, key.mode = "R", start = NULL, end = NULL, dsd = FALSE,
-  headers = list(), validate = FALSE,
+  headers = list(), validate = FALSE, references = NULL,
   verbose = !is.null(logger), logger = "INFO", ...)
 }
 \arguments{

--- a/tests/testthat/test_Main_Helpers.R
+++ b/tests/testthat/test_Main_Helpers.R
@@ -164,6 +164,37 @@ test_that("IMF - data",{
   #}
 })
 
+#IMF_DATA
+#----
+
+#-> dataflow
+test_that("IMF_DATA - dataflow",{
+  testthat::skip_on_cran()
+  sdmx <- readSDMX(providerId = "IMF_DATA", resource = "dataflow")
+  if(!is.null(sdmx)){
+    expect_is(sdmx, "SDMXDataFlows")
+  }
+})
+
+#-> datastructure
+test_that("IMF_DATA - datastructure",{
+  testthat::skip_on_cran()
+  sdmx <- readSDMX(providerId = "IMF_DATA", resource = "datastructure", resourceId = "IMF.STA,DSD_CPI")
+  if(!is.null(sdmx)){
+    expect_is(sdmx, "SDMXDataStructureDefinition")
+  }
+})
+
+#-> data
+test_that("IMF_DATA - data",{
+  testthat::skip_on_cran()
+  sdmx <- readSDMX(providerId = "IMF_DATA", resource = "data", flowRef = "IMF.STA,CPI",
+                   key = list("USA", "CPI", "CP01", "IX", "A"), start = 2020, end = 2020)
+  if(!is.null(sdmx)){
+    expect_is(sdmx, "SDMXStructureSpecificData")
+  }
+})
+
 #OECD
 #----
 

--- a/tests/testthat/test_Main_Helpers.R
+++ b/tests/testthat/test_Main_Helpers.R
@@ -154,15 +154,7 @@ test_that("IMF - datastructure",{
   }
 })
 
-#-> data
-test_that("IMF - data",{
-  testthat::skip_on_cran()
-  #TODO to test, sounds it's not public anymore
-  #sdmx <- readSDMX(providerId = "IMF", resource = "data", flowRef = "BOP_GBPM6", start = 2020, end = 2020) 
-  #if(!is.null(sdmx)){
-  #  expect_is(sdmx, "SDMXStructureSpecificData")
-  #}
-})
+#No plans to dissiminate data on IMF provider, IMF data avaliable on IMF_DATA.
 
 #IMF_DATA
 #----


### PR DESCRIPTION
The goal of this pull request is to allow IMF_DATA to use dsd=true. These DSDs only directly reference concepts in concept schemes so the references parameter needs to be passed to get the code lists. 

Add references to request parameters and it's method.

Modify SDMXREST21Request builder to use references for datastructure resources

Modify readSDMX:
1. accept the refrences parameter
2. use the refrences parameter when trying to read a DSD
3. set references = 'descendants' if references was Null and providerID = IMF_DATA

Allow dsd=True to work for core representation by trying to resolve codelist against concept scheme reference.

Update tests to cover IMF_DATA service provider

Update IMF tests to cover how that service provider is envisioned to be used (we have no plans to enable data querying)